### PR TITLE
demangling doesn't work with large binaries

### DIFF
--- a/plasma/lib/fileformat/binary.py
+++ b/plasma/lib/fileformat/binary.py
@@ -345,9 +345,8 @@ class Binary(object):
 
         # http://stackoverflow.com/questions/6526500/c-name-mangling-library-for-python
         args = ["c++filt", "-p"]
-        args.extend(lookup_names)
         pipe = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        stdout, _ = pipe.communicate()
+        stdout, _ = pipe.communicate('\n'.join(lookup_names).encode('utf-8'))
         demangled = stdout.split(b"\n")[:-1]
 
         self.reverse_demangled = dict(zip(addr, demangled))


### PR DESCRIPTION
I tried plasma-disassembler with a large binary with many mangled function names. I got the following error message:
```
  File "plasma/lib/fileformat/binary.py", line 349, in demangle_symbols
    pipe = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
  File "/usr/lib/python3.5/subprocess.py", line 676, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.5/subprocess.py", line 1282, in _execute_child
    raise child_exception_type(errno_num, err_msg)
OSError: [Errno 7] Argument list too long
```