### PR TITLE
Fix setup.py for pip10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,11 @@ try:
 except ImportError:
     from distutils.core import setup
 
+try:
+    from pip._internal.req import parse_requirements
+except ImportError:
+    from pip.req import parse_requirements
 
-from pip.req import parse_requirements
 from distutils.core import Extension
 import plasma
 


### PR DESCRIPTION
According to [the offical announce](https://mail.python.org/pipermail/distutils-sig/2017-October/031642.html), the pip.req module is no longer available after pip 10. 

A fix provided by [mlissner](https://stackoverflow.com/users/64911/mlissner) in [StackOverflow](https://stackoverflow.com/questions/25192794/no-module-named-pip-req?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa). 