### PR TITLE
Rename msgpack-python to msgpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ database compatibility could be broken.
 * [capstone](https://github.com/aquynh/capstone), tested with 4.0-alpha5
 * [python-pyelftools](https://github.com/eliben/pyelftools)
 * [pefile](https://github.com/erocarrera/pefile) + python3-future
-* [python-msgpack](https://github.com/msgpack/msgpack-python) >= 0.4.6
+* [msgpack](https://github.com/msgpack/msgpack-python)
 * `c++filt` (available in the binutils Linux package)
 * terminal should support UTF8 and 256 colors (if not, use the option `--nocolor`)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pefile
 pyelftools
-msgpack-python>=0.4.6
+msgpack
 nose


### PR DESCRIPTION
msgpack-python is renamed to msgpack now.